### PR TITLE
Add configuration file support (.phpcop.json)

### DIFF
--- a/.phpcop.json.example
+++ b/.phpcop.json.example
@@ -1,0 +1,12 @@
+{
+  "format": "table",
+  "stale-months": 18,
+  "fail-on": "high",
+  "composer-bin": "composer",
+  "quiet": false,
+  "ignore-packages": [
+    "symfony/polyfill-*",
+    "psr/log",
+    "doctrine/lexer"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -104,7 +104,27 @@ phpcop scan --composer-bin=composer.bat
    └─ 🚨 high CVE-2023-12345 https://cve.mitre.org/...
 ```
 
-## Options
+## Configuration
+
+### Configuration File
+
+Create a `.phpcop.json` file in your project root for persistent settings:
+
+```json
+{
+  "format": "table",
+  "stale-months": 18,
+  "fail-on": "high",
+  "composer-bin": "composer",
+  "quiet": false,
+  "ignore-packages": [
+    "symfony/polyfill-*",
+    "psr/log"
+  ]
+}
+```
+
+### Command Options
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -112,6 +132,11 @@ phpcop scan --composer-bin=composer.bat
 | `--stale-months` | `18` | Months to flag packages as stale |
 | `--fail-on` | `high` | Minimum severity to fail: `low`, `moderate`, `high`, `critical` |
 | `--composer-bin` | `composer` | Path to composer executable |
+| `--quiet`, `-q` | `false` | Disable progress bar and animations |
+| `--config`, `-c` | `.phpcop.json` | Path to configuration file |
+| `--ignore-packages` | `[]` | Comma-separated packages to ignore |
+
+**Note:** Command-line options override configuration file settings.
 
 ## Requirements
 

--- a/src/Services/ConfigReader.php
+++ b/src/Services/ConfigReader.php
@@ -1,0 +1,67 @@
+<?php
+namespace PHPCop\Services;
+
+final class ConfigReader
+{
+    public function readConfig(string $configFile = '.phpcop.json'): array
+    {
+        if (!is_file($configFile)) {
+            return [];
+        }
+
+        $content = file_get_contents($configFile);
+        if ($content === false) {
+            throw new \RuntimeException("Unable to read config file: {$configFile}");
+        }
+
+        try {
+            $config = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException("Invalid JSON in config file {$configFile}: " . $e->getMessage());
+        }
+
+        return $this->validateConfig($config ?? []);
+    }
+
+    private function validateConfig(array $config): array
+    {
+        $defaults = [
+            'format' => 'table',
+            'stale-months' => 18,
+            'fail-on' => 'high',
+            'composer-bin' => 'composer',
+            'quiet' => false,
+            'ignore-packages' => [],
+        ];
+
+        // Merge with defaults
+        $config = array_merge($defaults, $config);
+
+        // Validate format
+        if (!in_array($config['format'], ['table', 'json', 'md', 'html'])) {
+            throw new \RuntimeException("Invalid format '{$config['format']}'. Must be: table, json, md, html");
+        }
+
+        // Validate fail-on
+        if (!in_array($config['fail-on'], ['low', 'moderate', 'high', 'critical'])) {
+            throw new \RuntimeException("Invalid fail-on '{$config['fail-on']}'. Must be: low, moderate, high, critical");
+        }
+
+        // Validate stale-months
+        if (!is_int($config['stale-months']) || $config['stale-months'] < 1) {
+            throw new \RuntimeException("stale-months must be a positive integer");
+        }
+
+        // Validate ignore-packages is array
+        if (!is_array($config['ignore-packages'])) {
+            throw new \RuntimeException("ignore-packages must be an array of package names");
+        }
+
+        // Validate quiet is boolean
+        if (!is_bool($config['quiet'])) {
+            throw new \RuntimeException("quiet must be a boolean (true/false)");
+        }
+
+        return $config;
+    }
+}


### PR DESCRIPTION
- Add ConfigReader service for parsing and validating config files
- Support .phpcop.json with all command options as defaults
- CLI options override config file settings
- Add ignore-packages feature for both config and CLI
- Include comprehensive validation with helpful error messages
- Update README with configuration documentation
- Add .phpcop.json.example for users
- Maintain full backward compatibility