### PR TITLE
Implement missing Markdown and HTML output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,37 @@ php phpcop.phar scan
 phpcop scan
 ```
 
-### Custom Options
+### Output Formats
 ```bash
-# JSON output
+# Terminal-friendly table (default)
+phpcop scan --format=table
+
+# JSON for automation/CI
 phpcop scan --format=json
 
+# Markdown for documentation
+phpcop scan --format=md > security-report.md
+
+# HTML for web viewing
+phpcop scan --format=html > report.html
+```
+
+### Custom Options
+```bash
 # Custom staleness threshold (12 months)
 phpcop scan --stale-months=12
 
 # Fail on moderate vulnerabilities instead of high
 phpcop scan --fail-on=moderate
 
-# Use custom composer binary
-phpcop scan --composer-bin=composer.bat
+# Ignore specific packages
+phpcop scan --ignore-packages=vendor/package,psr/log
+
+# Use custom config file
+phpcop scan --config=custom-config.json
+
+# Silent mode for automation
+phpcop scan --quiet
 ```
 
 ### Sample Output

--- a/src/Console/ScanCommand.php
+++ b/src/Console/ScanCommand.php
@@ -121,23 +121,21 @@ final class ScanCommand extends Command
         }
 
         $format = $options['format'];
-        if ($format === 'table') {
-            $out->writeln("<info>🚓 PHP Cop: Dependency Patrol — Case File</info>");
-            $out->writeln(str_repeat('-', 80));
-            foreach ($issues as $i) {
-                $badges = [];
-                if ($i['pkgAdvisories']) $badges[] = '⚠️ Vulns';
-                if ($i['abandoned'])     $badges[] = '🚫 Abandoned';
-                if ($i['isOutdated'])    $badges[] = '⬆️ Outdated → '.$i['latestDisp'];
-                if ($i['isStale'])       $badges[] = '⌛ Stale';
-                $out->writeln(sprintf("• %s %s  [%s]", $i['name'], $i['version'], implode(' ', $badges)));
-                foreach ($i['pkgAdvisories'] as $a) {
-                    $out->writeln("   └─ 🚨 {$a['severity']} {$a['title']} {$a['link']}");
-                }
-            }
-        } else {
-            $payload = ['generatedAt'=> (new \DateTimeImmutable())->format(\DateTime::ATOM),'issues'=>$issues];
-            $out->writeln(json_encode($payload, JSON_PRETTY_PRINT));
+        switch ($format) {
+            case 'table':
+                $this->outputTable($out, $issues);
+                break;
+            case 'json':
+                $this->outputJson($out, $issues);
+                break;
+            case 'md':
+                $this->outputMarkdown($out, $issues);
+                break;
+            case 'html':
+                $this->outputHtml($out, $issues);
+                break;
+            default:
+                throw new \RuntimeException("Unsupported format: {$format}");
         }
 
         $thresholdMap = ['low'=>1,'moderate'=>2,'high'=>3,'critical'=>4];
@@ -150,6 +148,138 @@ final class ScanCommand extends Command
         }
 
         return ($max >= $threshold) ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function outputTable(Out $out, array $issues): void
+    {
+        $out->writeln("<info>🚓 PHP Cop: Dependency Patrol — Case File</info>");
+        $out->writeln(str_repeat('-', 80));
+        foreach ($issues as $i) {
+            $badges = [];
+            if ($i['pkgAdvisories']) $badges[] = '⚠️ Vulns';
+            if ($i['abandoned'])     $badges[] = '🚫 Abandoned';
+            if ($i['isOutdated'])    $badges[] = '⬆️ Outdated → '.$i['latestDisp'];
+            if ($i['isStale'])       $badges[] = '⌛ Stale';
+            $out->writeln(sprintf("• %s %s  [%s]", $i['name'], $i['version'], implode(' ', $badges)));
+            foreach ($i['pkgAdvisories'] as $a) {
+                $out->writeln("   └─ 🚨 {$a['severity']} {$a['title']} {$a['link']}");
+            }
+        }
+    }
+
+    private function outputJson(Out $out, array $issues): void
+    {
+        $payload = ['generatedAt'=> (new \DateTimeImmutable())->format(\DateTime::ATOM),'issues'=>$issues];
+        $out->writeln(json_encode($payload, JSON_PRETTY_PRINT));
+    }
+
+    private function outputMarkdown(Out $out, array $issues): void
+    {
+        $out->writeln("# 🚓 PHP Cop: Dependency Patrol — Case File");
+        $out->writeln("");
+        $out->writeln("Generated: " . (new \DateTimeImmutable())->format('Y-m-d H:i:s T'));
+        $out->writeln("");
+
+        if (empty($issues)) {
+            $out->writeln("✅ **No issues found!** All dependencies are secure and up-to-date.");
+            return;
+        }
+
+        $out->writeln("## Issues Found");
+        $out->writeln("");
+
+        foreach ($issues as $i) {
+            $badges = [];
+            if ($i['pkgAdvisories']) $badges[] = '⚠️ **Vulnerabilities**';
+            if ($i['abandoned'])     $badges[] = '🚫 **Abandoned**';
+            if ($i['isOutdated'])    $badges[] = "⬆️ **Outdated** → `{$i['latestDisp']}`";
+            if ($i['isStale'])       $badges[] = '⌛ **Stale**';
+
+            $out->writeln("### `{$i['name']}` v{$i['version']}");
+            $out->writeln("");
+            $out->writeln(implode(' | ', $badges));
+            $out->writeln("");
+
+            if ($i['pkgAdvisories']) {
+                $out->writeln("**Security Advisories:**");
+                foreach ($i['pkgAdvisories'] as $a) {
+                    $severity = strtoupper($a['severity']);
+                    $out->writeln("- 🚨 **{$severity}**: {$a['title']} ([Link]({$a['link']}))");
+                }
+                $out->writeln("");
+            }
+        }
+    }
+
+    private function outputHtml(Out $out, array $issues): void
+    {
+        $out->writeln("<!DOCTYPE html>");
+        $out->writeln("<html lang='en'>");
+        $out->writeln("<head>");
+        $out->writeln("    <meta charset='UTF-8'>");
+        $out->writeln("    <meta name='viewport' content='width=device-width, initial-scale=1.0'>");
+        $out->writeln("    <title>🚓 PHP Cop: Dependency Patrol — Case File</title>");
+        $out->writeln("    <style>");
+        $out->writeln("        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 40px; background: #f8f9fa; }");
+        $out->writeln("        .container { max-width: 1000px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }");
+        $out->writeln("        .header { text-align: center; margin-bottom: 30px; padding-bottom: 20px; border-bottom: 2px solid #e9ecef; }");
+        $out->writeln("        .package { margin: 20px 0; padding: 20px; border: 1px solid #dee2e6; border-radius: 6px; background: #fff; }");
+        $out->writeln("        .package-name { font-size: 1.3em; font-weight: bold; color: #495057; margin-bottom: 10px; }");
+        $out->writeln("        .badges { margin: 10px 0; }");
+        $out->writeln("        .badge { display: inline-block; padding: 4px 8px; margin: 2px; border-radius: 4px; font-size: 0.85em; font-weight: 500; }");
+        $out->writeln("        .badge.vuln { background: #f8d7da; color: #721c24; }");
+        $out->writeln("        .badge.abandoned { background: #f1c40f; color: #856404; }");
+        $out->writeln("        .badge.outdated { background: #d4edda; color: #155724; }");
+        $out->writeln("        .badge.stale { background: #ffeaa7; color: #856404; }");
+        $out->writeln("        .advisory { margin: 8px 0; padding: 10px; background: #fff5f5; border-left: 4px solid #e74c3c; }");
+        $out->writeln("        .severity { font-weight: bold; text-transform: uppercase; }");
+        $out->writeln("        .severity.critical { color: #c0392b; }");
+        $out->writeln("        .severity.high { color: #e74c3c; }");
+        $out->writeln("        .severity.moderate { color: #f39c12; }");
+        $out->writeln("        .severity.low { color: #f1c40f; }");
+        $out->writeln("        .no-issues { text-align: center; color: #27ae60; font-size: 1.2em; margin: 40px 0; }");
+        $out->writeln("    </style>");
+        $out->writeln("</head>");
+        $out->writeln("<body>");
+        $out->writeln("    <div class='container'>");
+        $out->writeln("        <div class='header'>");
+        $out->writeln("            <h1>🚓 PHP Cop: Dependency Patrol — Case File</h1>");
+        $out->writeln("            <p>Generated: " . (new \DateTimeImmutable())->format('Y-m-d H:i:s T') . "</p>");
+        $out->writeln("        </div>");
+
+        if (empty($issues)) {
+            $out->writeln("        <div class='no-issues'>✅ No issues found! All dependencies are secure and up-to-date.</div>");
+        } else {
+            foreach ($issues as $i) {
+                $out->writeln("        <div class='package'>");
+                $out->writeln("            <div class='package-name'>{$i['name']} <code>v{$i['version']}</code></div>");
+                $out->writeln("            <div class='badges'>");
+
+                if ($i['pkgAdvisories']) $out->writeln("                <span class='badge vuln'>⚠️ Vulnerabilities</span>");
+                if ($i['abandoned'])     $out->writeln("                <span class='badge abandoned'>🚫 Abandoned</span>");
+                if ($i['isOutdated'])    $out->writeln("                <span class='badge outdated'>⬆️ Outdated → {$i['latestDisp']}</span>");
+                if ($i['isStale'])       $out->writeln("                <span class='badge stale'>⌛ Stale</span>");
+
+                $out->writeln("            </div>");
+
+                if ($i['pkgAdvisories']) {
+                    foreach ($i['pkgAdvisories'] as $a) {
+                        $severity = strtolower($a['severity']);
+                        $out->writeln("            <div class='advisory'>");
+                        $out->writeln("                <strong class='severity {$severity}'>{$a['severity']}</strong>: {$a['title']}");
+                        if ($a['link']) {
+                            $out->writeln("                <br><a href='{$a['link']}' target='_blank'>View Advisory</a>");
+                        }
+                        $out->writeln("            </div>");
+                    }
+                }
+                $out->writeln("        </div>");
+            }
+        }
+
+        $out->writeln("    </div>");
+        $out->writeln("</body>");
+        $out->writeln("</html>");
     }
 
     private function mergeOptions(array $config, In $input): array


### PR DESCRIPTION
- Add proper support for --format=md and --format=html options
- Refactor output logic with dedicated methods for each format
- Create professional HTML reports with responsive CSS styling
- Generate GitHub-ready Markdown documentation format
- Add color-coded severity levels and structured layouts
- Update README with output format examples and usage
- Maintain full backward compatibility with existing formats
- Fix broken promise in documentation about supported formats